### PR TITLE
fix: update issue URL

### DIFF
--- a/custom_components/em6/sensor.py
+++ b/custom_components/em6/sensor.py
@@ -20,7 +20,8 @@ from .const import (
 )
 
 NAME = DOMAIN
-ISSUEURL = "https://github.com/codyc1515/hacs_em6/issues"
+# Repository issue tracker for this integration
+ISSUEURL = "https://github.com/codyc1515/ha-em6/issues"
 
 STARTUP = f"""
 -------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- fix issue tracker URL for EM6 integration

## Testing
- `python -m py_compile custom_components/em6/sensor.py`
- ⚠️ `pip install voluptuous` *(failed: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689c06edc5c4832789c249b777036f57