### PR TITLE
Handle HTTP error in em6 API

### DIFF
--- a/custom_components/em6/api.py
+++ b/custom_components/em6/api.py
@@ -16,16 +16,16 @@ class em6Api:
             "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36 Edg/111.0.1661.54"
         }
         response = requests.get(self._url_base + "region/price", headers=headers)
-        
+
         if response.status_code == requests.codes.ok:
             data = response.json()
             if not data:
                 _LOGGER.warning('Fetched prices successfully, but did not find any')
-                
-            if data['items']:
+
+            if data.get('items'):
                 for location in data['items']:
                     if location['grid_zone_name'] == self._location:
                         return location
         else:
-            _LOGGER.error('Failed to fetch prices')
-            return data
+            _LOGGER.error('Failed to fetch prices: %s', response.status_code)
+            return None

--- a/custom_components/em6/api.py
+++ b/custom_components/em6/api.py
@@ -15,7 +15,11 @@ class em6Api:
         headers = {
             "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36 Edg/111.0.1661.54"
         }
-        response = requests.get(self._url_base + "region/price", headers=headers)
+        try:
+            response = requests.get(self._url_base + "region/price", headers=headers)
+        except requests.exceptions.RequestException as err:
+            _LOGGER.error('Failed to fetch prices: %s', err)
+            return None
 
         if response.status_code == requests.codes.ok:
             data = response.json()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,28 @@
+import sys
+import types
+
+class DummyResponse:
+    def __init__(self, status_code, payload=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+# Insert a dummy requests module so api.py can import it without the real dependency
+sys.modules['requests'] = types.SimpleNamespace(
+    get=lambda *args, **kwargs: DummyResponse(500),
+    codes=types.SimpleNamespace(ok=200),
+)
+
+from custom_components.em6.api import em6Api
+
+def test_get_prices_handles_http_error(monkeypatch):
+    def fake_get(*args, **kwargs):
+        return DummyResponse(500)
+
+    import requests  # this is our dummy module
+    monkeypatch.setattr(requests, 'get', fake_get)
+
+    api = em6Api("Somewhere")
+    assert api.get_prices() is None


### PR DESCRIPTION
## Summary
- prevent NameError when API request fails in `get_prices`
- add regression test for API error handling

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c05b5df748327b961e9219407e895