### PR TITLE
fix: correct issue tracker URL

### DIFF
--- a/custom_components/em6/manifest.json
+++ b/custom_components/em6/manifest.json
@@ -5,7 +5,7 @@
   "dependencies": [],
   "documentation": "https://github.com/codyc1515/ha-em6",
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/codyc15/ha-em6/issues",
+  "issue_tracker": "https://github.com/codyc1515/ha-em6/issues",
   "requirements": [],
   "version": "1.0.0"
 }


### PR DESCRIPTION
## Summary
- fix issue tracker link to point to codyc1515/ha-em6

## Testing
- `pytest`
- `python -m json.tool custom_components/em6/manifest.json`


------
https://chatgpt.com/codex/tasks/task_e_689c070544bc832785f2309a5d475030