### PR TITLE
Refactor API to use aiohttp and async methods

### DIFF
--- a/custom_components/em6/config_flow.py
+++ b/custom_components/em6/config_flow.py
@@ -24,7 +24,7 @@ class em6ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_create_entry(title=user_input[CONF_LOCATION], data=user_input)
 
         api = em6Api()
-        locations = await self.hass.async_add_executor_job(api.get_locations)
+        locations = await api.async_get_locations()
         if not locations:
             errors["base"] = "cannot_connect"
             locations = []

--- a/custom_components/em6/sensor.py
+++ b/custom_components/em6/sensor.py
@@ -108,14 +108,14 @@ class em6EnergyPriceSensor(Entity):
         """Return the unique id."""
         return self._unique_id
 
-    def update(self):
+    async def async_update(self):
         _LOGGER.debug('Fetching prices')
-        response = self._api.get_prices()
-        
+        response = await self._api.async_get_prices()
+
         if response:
             _LOGGER.debug('Found price')
             _LOGGER.debug(response)
-            
+
             # Avoid updating the price (state) if the price is still the same or we will get duplicate notifications
             if self._state != response['price'] / 1000:
                 self._state = response['price'] / 1000


### PR DESCRIPTION
## Summary
- migrate em6 API to aiohttp and async calls
- update config flow and sensor to use asynchronous API methods

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c0a6ac9048327b1497c47007b156c